### PR TITLE
update: rename master branch to main

### DIFF
--- a/Classes/ARAppDelegate.m
+++ b/Classes/ARAppDelegate.m
@@ -213,7 +213,7 @@ void uncaughtExceptionHandler(NSException *exception);
         NSLog(@"NSZombieEnabled/NSAutoreleaseFreedObjectCheckEnabled enabled!");
     }
 
-// https://github.com/groue/GRMustache/blob/master/Guides/runtime.md
+// https://github.com/groue/GRMustache/blob/main/Guides/runtime.md
 #if !defined(NS_BLOCK_ASSERTIONS)
     [GRMustache preventNSUndefinedKeyExceptionAttack];
 #endif

--- a/Classes/Models/Artwork.h
+++ b/Classes/Models/Artwork.h
@@ -4,7 +4,7 @@
 
 @class Image;
 
-// https://github.com/artsy/gravity/blob/master/app/models/domain/availability.rb
+// https://github.com/artsy/gravity/blob/main/app/models/domain/availability.rb
 
 typedef NS_ENUM(NSInteger, ARArtworkAvailability) {
     ARArtworkAvailabilityForSale,

--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ LOCAL_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 BRANCH = $(shell echo $(shell whoami)-$(shell git rev-parse --abbrev-ref HEAD))
 
 pr:
-	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not PRing"; else git push origin "$(LOCAL_BRANCH):$(BRANCH)"; open "https://github.com/artsy/energy/pull/new/artsy:master...$(BRANCH)"; fi
+	if [ "$(LOCAL_BRANCH)" == "main" ]; then echo "In main, not PRing"; else git push origin "$(LOCAL_BRANCH):$(BRANCH)"; open "https://github.com/artsy/energy/pull/new/artsy:main...$(BRANCH)"; fi
 
 push:
-	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not pushing"; else git push origin $(LOCAL_BRANCH):$(BRANCH); fi
+	if [ "$(LOCAL_BRANCH)" == "main" ]; then echo "In main, not pushing"; else git push origin $(LOCAL_BRANCH):$(BRANCH); fi
 
 fpush:
-	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not pushing"; else git push origin $(LOCAL_BRANCH):$(BRANCH) --force; fi
+	if [ "$(LOCAL_BRANCH)" == "main" ]; then echo "In main, not pushing"; else git push origin $(LOCAL_BRANCH):$(BRANCH) --force; fi

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<img src="https://raw.githubusercontent.com/artsy/energy/master/docs/screenshots/artsy_logo.png" align="left">
-<img src="https://raw.githubusercontent.com/artsy/energy/master/docs/screenshots/energy.png" align="right">
+<img src="https://raw.githubusercontent.com/artsy/energy/main/docs/screenshots/artsy_logo.png" align="left">
+<img src="https://raw.githubusercontent.com/artsy/energy/main/docs/screenshots/energy.png" align="right">
 
 
-<a href="http://folio.artsy.net"><img src ="https://raw.githubusercontent.com/artsy/energy/master/docs/screenshots/folio_screenshots.jpg" width="100%"></a>
+<a href="http://folio.artsy.net"><img src ="https://raw.githubusercontent.com/artsy/energy/main/docs/screenshots/folio_screenshots.jpg" width="100%"></a>
 
 The iPhone and iPad app that brings all the Partners to the yard.
 
@@ -14,7 +14,7 @@ The iPhone and iPad app that brings all the Partners to the yard.
 
 This is a core [Artsy Mobile](https://github.com/artsy/mobile) OSS project, along with [Eigen](https://github.com/artsy/eigen), [Eidolon](https://github.com/artsy/eidolon), [Emission](https://github.com/artsy/emission) and [Emergence](https://github.com/artsy/emergence).
 
-Don't know what Artsy is? [Check this](https://github.com/artsy/mobile/blob/master/what_is_artsy.md) overview, or read our objc.io on [team culture](https://www.objc.io/issues/22-scale/artsy/).
+Don't know what Artsy is? [Check this](https://github.com/artsy/mobile/blob/main/what_is_artsy.md) overview, or read our objc.io on [team culture](https://www.objc.io/issues/22-scale/artsy/).
 
 Want to know more about Eigen? Read the [mobile](http://artsy.github.io/blog/categories/mobile/) blog posts, or [energy's](http://artsy.github.io/blog/categories/energy/) specifically. There's some great overview videos that cover almost all of the code-base.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,7 @@
 Deployment
 ================
 
-Follows Eigen's [documentation](https://github.com/artsy/eigen/blob/master/docs/deploy_to_beta.md) - it's
+Follows Eigen's [documentation](https://github.com/artsy/eigen/blob/main/docs/deploy_to_beta.md) - it's
 more likely to be up-to-date and they should more-or-less be the same.
 
 ### Upon Successful Submission


### PR DESCRIPTION
Before renaming the default branch to main on github, we need to update the make file and the links in the readmes.